### PR TITLE
Инспектор больше не может быть ксеносом

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Justice/inspector.yml
+++ b/Resources/Prototypes/Roles/Jobs/Justice/inspector.yml
@@ -17,6 +17,8 @@
   icon: "JobIconInspector"
   arrivalNotificationPrototype: InspectorArrivalNotification
   supervisors: job-supervisors-captain
+  whitelistedSpecies: # Amour EDIT
+    - Human
   access:
     - Service
     - Lawyer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
	- Добавлено новое свойство `whitelistedSpecies` для роли Инспектора, ограничивающее доступ к работе только для вида "Человек".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->