### PR TITLE
Yellow Glowes on outerclothing Fix

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -88,7 +88,7 @@
 - type: startingGear
   id: AssistantHandsGlovesColorYellow
   equipment:
-    outerClothing: ClothingHandsGlovesColorYellow
+    gloves: ClothingHandsGlovesColorYellow
 
 - type: itemLoadout
   id: AssistantGloves


### PR DESCRIPTION
# Описание PR
Теперь изолирующие перчатки не появляются как внешняя одежда в лодаутах ассистента.

## Тип PR
- [ ] Feature
- [X] Fix
- [ ] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Translate
- [ ] Resprite

**Изменения**
:cl: Hero_010
- fix: Исправлено появление изолей в слоте внешней одежды при выборе в лодаутах.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Исправления**
	- Обновлена структура снаряжения для пассажиров
	- Изменены атрибуты перчаток и идентификатора
	- Уточнены параметры экипировки для различных предметов одежды

<!-- end of auto-generated comment: release notes by coderabbit.ai -->